### PR TITLE
Add metrics for Elasticsearch Cross Cluster Replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Further Information
 | elasticsearch_clusterinfo_last_retrieval_success_ts                   | gauge     | 1           | Timestamp of the last successful cluster info retrieval
 | elasticsearch_clusterinfo_up                                          | gauge     | 1           | Up metric for the cluster info collector
 | elasticsearch_clusterinfo_version_info                                | gauge     | 6           | Constant metric with ES version information as labels
+| elasticsearch_ccr_follower_global_checkpoint                          | gauge     | ?           | Test description
 
 ### Alerts & Recording Rules
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Elasticsearch Exporter
+
 [![CircleCI](https://circleci.com/gh/prometheus-community/elasticsearch_exporter.svg?style=svg)](https://circleci.com/gh/prometheus-community/elasticsearch_exporter)
 [![Go Report Card](https://goreportcard.com/badge/github.com/prometheus-community/elasticsearch_exporter)](https://goreportcard.com/report/github.com/prometheus-community/elasticsearch_exporter)
 
@@ -20,23 +21,29 @@ Example `docker-compose.yml`:
 
 ```yaml
 elasticsearch_exporter:
-    image: quay.io/prometheuscommunity/elasticsearch-exporter:latest
-    command:
-     - '--es.uri=http://elasticsearch:9200'
-    restart: always
-    ports:
+  image: quay.io/prometheuscommunity/elasticsearch-exporter:latest
+  command:
+    - '--es.uri=http://elasticsearch:9200'
+  restart: always
+  ports:
     - "127.0.0.1:9114:9114"
 ```
 
 #### Kubernetes
 
-You can find a helm chart in the stable charts repository at https://github.com/kubernetes/charts/tree/master/stable/elasticsearch-exporter.
+You can find a helm chart in the stable charts repository
+at https://github.com/kubernetes/charts/tree/master/stable/elasticsearch-exporter.
 
 ### Configuration
 
-**NOTE:** The exporter fetches information from an ElasticSearch cluster on every scrape, therefore having a too short scrape interval can impose load on ES master nodes, particularly if you run with `--es.all` and `--es.indices`. We suggest you measure how long fetching `/_nodes/stats` and `/_all/_stats` takes for your ES cluster to determine whether your scraping interval is too short. As a last resort, you can scrape this exporter using a dedicated job with its own scraping interval.
+**NOTE:** The exporter fetches information from an ElasticSearch cluster on every scrape, therefore having a too short
+scrape interval can impose load on ES master nodes, particularly if you run with `--es.all` and `--es.indices`. We
+suggest you measure how long fetching `/_nodes/stats` and `/_all/_stats` takes for your ES cluster to determine whether
+your scraping interval is too short. As a last resort, you can scrape this exporter using a dedicated job with its own
+scraping interval.
 
 Below is the command line options summary:
+
 ```bash
 elasticsearch_exporter --help
 ```
@@ -60,9 +67,10 @@ elasticsearch_exporter --help
 | web.telemetry-path      | 1.0.2                 | Path under which to expose metrics. | /metrics |
 | version                 | 1.0.2                 | Show version info on stdout and exit. | |
 
-Commandline parameters start with a single `-` for versions less than `1.1.0rc1`.
-For versions greater than `1.1.0rc1`, commandline parameters are specified with `--`. Also, all commandline parameters can be provided as environment variables. The environment variable name is derived from the parameter name
-by replacing `.` and `-` with `_` and upper-casing the parameter name.
+Commandline parameters start with a single `-` for versions less than `1.1.0rc1`. For versions greater than `1.1.0rc1`,
+commandline parameters are specified with `--`. Also, all commandline parameters can be provided as environment
+variables. The environment variable name is derived from the parameter name by replacing `.` and `-` with `_` and
+upper-casing the parameter name.
 
 #### Elasticsearch 7.x security privileges
 
@@ -78,6 +86,7 @@ es.shards | not sure if `indices` or `cluster` `monitor` or both |
 es.snapshots | `cluster:admin/snapshot/status` and `cluster:admin/repository/get` | [ES Forum Post](https://discuss.elastic.co/t/permissions-for-backup-user-with-x-pack/88057)
 
 Further Information
+
 - [Build in Users](https://www.elastic.co/guide/en/elastic-stack-overview/7.3/built-in-users.html)
 - [Defining Roles](https://www.elastic.co/guide/en/elastic-stack-overview/7.3/defining-roles.html)
 - [Privileges](https://www.elastic.co/guide/en/elastic-stack-overview/7.3/security-privileges.html)
@@ -209,14 +218,40 @@ Further Information
 | elasticsearch_clusterinfo_last_retrieval_success_ts                   | gauge     | 1           | Timestamp of the last successful cluster info retrieval
 | elasticsearch_clusterinfo_up                                          | gauge     | 1           | Up metric for the cluster info collector
 | elasticsearch_clusterinfo_version_info                                | gauge     | 6           | Constant metric with ES version information as labels
-| elasticsearch_ccr_follower_global_checkpoint                          | gauge     | ?           | Test description
+| elasticsearch_ccr_stats_leader_global_checkpoint                      | counter   |             | The current global checkpoint on the leader
+| elasticsearch_ccr_stats_leader_max_seq_no                             | counter   |             | The current maximum sequence number on the leader known to the follower task
+| elasticsearch_ccr_stats_follower_global_checkpoint                    | counter   |             | The current global checkpoint on the follower
+| elasticsearch_ccr_stats_follower_max_seq_no                           | counter   |             | The current maximum sequence number on the follower
+| elasticsearch_ccr_stats_last_requested_seq_no                         | counter   |             | The starting sequence number of the last batch of operations requested from the leader
+| elasticsearch_ccr_stats_outstanding_read_requests                     | counter   |             | The number of active read requests from the follower
+| elasticsearch_ccr_stats_outstanding_write_requests                    | counter   |             | The number of active bulk write requests on the follower
+| elasticsearch_ccr_stats_write_buffer_operation_count                  | counter   |             | The number of write operations queued on the follower
+| elasticsearch_ccr_stats_write_buffer_size_in_bytes                    | gauge     |             | The total number of bytes of operations currently queued for writing
+| elasticsearch_ccr_stats_follower_mapping_version                      | gauge     |             | The mapping version the follower is synced up to
+| elasticsearch_ccr_stats_follower_settings_version                     | gauge     |             | The index settings version the follower is synced up to
+| elasticsearch_ccr_stats_follower_aliases_version                      | gauge     |             | The index aliases version the follower is synced up to
+| elasticsearch_ccr_stats_total_read_time_millis                        | gauge     |             | The total time reads were outstanding, measured from the time a read was sent to the leader to the time a reply was returned to the follower
+| elasticsearch_ccr_stats_total_read_remote_exec_time_millis            | gauge     |             | The total time reads spent executing on the remote cluster
+| elasticsearch_ccr_stats_successful_read_requests                      | counter   |             | The number of successful fetches
+| elasticsearch_ccr_stats_failed_read_requests                          | counter   |             | The number of failed reads
+| elasticsearch_ccr_stats_operations_read                               | counter   |             | The total number of operations read from the leader
+| elasticsearch_ccr_stats_bytes_read                                    | counter   |             | The total of transferred bytes read from the leader. This is only an estimate and does not account for compression if enabled
+| elasticsearch_ccr_stats_total_write_time_millis                       | gauge     |             | The total time spent writing on the follower
+| elasticsearch_ccr_stats_successful_write_requests                     | counter   |             | The number of bulk write requests executed on the follower
+| elasticsearch_ccr_stats_failed_write_requests                         | counter   |             | The number of failed bulk write requests executed on the follower
+| elasticsearch_ccr_stats_operations_written                            | counter   |             | The number of operations written on the follower
+| elasticsearch_ccr_stats_time_since_last_read_millis                   | gauge     |             | The number of milliseconds since a read request was sent to the leader
 
 ### Alerts & Recording Rules
 
-We provide examples for [Prometheus](http://prometheus.io) [alerts and recording rules](examples/prometheus/elasticsearch.rules) as well as an [Grafana](http://www.grafana.org) [Dashboard](examples/grafana/dashboard.json) and a [Kubernetes](http://kubernetes.io) [Deployment](examples/kubernetes/deployment.yml).
+We provide examples
+for [Prometheus](http://prometheus.io) [alerts and recording rules](examples/prometheus/elasticsearch.rules) as well as
+an [Grafana](http://www.grafana.org) [Dashboard](examples/grafana/dashboard.json) and
+a [Kubernetes](http://kubernetes.io) [Deployment](examples/kubernetes/deployment.yml).
 
-The example dashboard needs the [node_exporter](https://github.com/prometheus/node_exporter) installed. In order to select the nodes that belong to the ElasticSearch cluster, we rely on a label `cluster`.
-Depending on your setup, it can derived from the platform metadata:
+The example dashboard needs the [node_exporter](https://github.com/prometheus/node_exporter) installed. In order to
+select the nodes that belong to the ElasticSearch cluster, we rely on a label `cluster`. Depending on your setup, it can
+derived from the platform metadata:
 
 For example on [GCE](https://cloud.google.com)
 
@@ -229,17 +264,18 @@ For example on [GCE](https://cloud.google.com)
   action: replace
 ```
 
-Please refer to the [Prometheus SD documentation](https://prometheus.io/docs/operating/configuration/) to see which metadata labels can be used to create the `cluster` label.
+Please refer to the [Prometheus SD documentation](https://prometheus.io/docs/operating/configuration/) to see which
+metadata labels can be used to create the `cluster` label.
 
 ## Credit & License
 
 `elasticsearch_exporter` is maintained by the [Prometheus Community](https://www.prometheus.io/community/).
 
-`elasticsearch_exporter` was then maintained by the nice folks from [JustWatch](https://www.justwatch.com/).
-Then transferred this repository to the Prometheus Community in May 2021.
+`elasticsearch_exporter` was then maintained by the nice folks from [JustWatch](https://www.justwatch.com/). Then
+transferred this repository to the Prometheus Community in May 2021.
 
-This package was originally created and maintained by [Eric Richardson](https://github.com/ewr),
-who transferred this repository to us in January 2017.
+This package was originally created and maintained by [Eric Richardson](https://github.com/ewr), who transferred this
+repository to us in January 2017.
 
 Maintainers of this repository:
 
@@ -249,8 +285,7 @@ Please refer to the Git commit log for a complete list of contributors.
 
 ## Contributing
 
-We welcome any contributions. Please fork the project on GitHub and open
-Pull Requests for any proposed changes.
+We welcome any contributions. Please fork the project on GitHub and open Pull Requests for any proposed changes.
 
-Please note that we will not merge any changes that encourage insecure
-behaviour. If in doubt please open an Issue first to discuss your proposal.
+Please note that we will not merge any changes that encourage insecure behaviour. If in doubt please open an Issue first
+to discuss your proposal.

--- a/collector/ccr_stats.go
+++ b/collector/ccr_stats.go
@@ -1,0 +1,423 @@
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/go-kit/kit/log/level"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"net/url"
+	"path"
+	"strconv"
+)
+
+// CCRStats information struct
+type CCRStats struct {
+	logger log.Logger
+	client *http.Client
+	url    *url.URL
+
+	up                              prometheus.Gauge
+	totalScrapes, jsonParseFailures prometheus.Counter
+	ccrMetrics                      []*IndexCCRStatsShardMetric
+}
+
+type IndexCCRStatsShardMetric struct {
+	Type   prometheus.ValueType
+	Desc   *prometheus.Desc
+	Value  func(shardCCRStats IndexCCRStatsShardResponse) float64
+	Labels func(indexCCRStatsShard IndexCCRStatsShardResponse) []string
+}
+
+var (
+	defaultCCRStatsLabels = []string{"follower_index", "leader_index", "remote_cluster", "shard_id"}
+	defaultCCRLabelValues = func(indexCCRStatsShard IndexCCRStatsShardResponse) []string {
+		return []string{indexCCRStatsShard.FollowerIndex, indexCCRStatsShard.LeaderIndex, indexCCRStatsShard.RemoteCluster, strconv.Itoa(int(indexCCRStatsShard.ShardID))}
+	}
+)
+
+// NewCCRStats defines CCRStats Prometheus metrics
+func NewCCRStats(logger log.Logger, client *http.Client, url *url.URL) *CCRStats {
+	return &CCRStats{
+		logger: logger,
+		client: client,
+		url:    url,
+
+		up: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: prometheus.BuildFQName(namespace, "ccr_stats", "up"),
+			Help: "Was the last scrape of the ElasticSearch ccr stats endpoint successful.",
+		}),
+		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: prometheus.BuildFQName(namespace, "ccr_stats", "total_scrapes"),
+			Help: "Current total ElasticSearch ccr stats scrapes.",
+		}),
+		jsonParseFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: prometheus.BuildFQName(namespace, "ccr_stats", "json_parse_failures"),
+			Help: "Number of errors while parsing JSON.",
+		}),
+		ccrMetrics: []*IndexCCRStatsShardMetric{
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "leader_global_checkpoint"),
+					"The current global checkpoint on the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.LeaderGlobalCheckpoint)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "leader_max_seq_no"),
+					"The current maximum sequence number on the leader known to the follower task",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.LeaderMaxSeqNo)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "follower_global_checkpoint"),
+					"The current global checkpoint on the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.FollowerGlobalCheckpoint)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "follower_max_seq_no"),
+					"The current maximum sequence number on the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.FollowerMaxSeqNo)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "last_requested_seq_no"),
+					"The starting sequence number of the last batch of operations requested from the leader",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.LastRequestedSeqNo)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "outstanding_read_requests"),
+					"The number of active read requests from the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.OutstandingReadRequests)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "outstanding_write_requests"),
+					"The number of active bulk write requests on the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.OutstandingWriteRequests)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "write_buffer_operation_count"),
+					"The number of write operations queued on the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.WriteBufferOperationCount)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "write_buffer_size_in_bytes"),
+					"The total number of bytes of operations currently queued for writing",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.WriteBufferSizeInBytes)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "follower_mapping_version"),
+					"The mapping version the follower is synced up to",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.FollowerMappingVersion)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "follower_settings_version"),
+					"The index settings version the follower is synced up to",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.FollowerSettingsVersion)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "follower_aliases_version"),
+					"The index aliases version the follower is synced up to",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.FollowerAliasesVersion)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "total_read_time_millis"),
+					"The total time reads were outstanding, measured from the time a read was sent to the leader to the time a reply was returned to the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.TotalReadTimeMillis)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "total_read_remote_exec_time_millis"),
+					"The total time reads spent executing on the remote cluster",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.TotalReadRemoteExecTimeMillis)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "successful_read_requests"),
+					"The number of successful fetches",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.SuccessfulReadRequests)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "failed_read_requests"),
+					"The number of failed reads",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.FailedReadRequests)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "operations_read"),
+					"The total number of operations read from the leader",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.OperationsRead)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "bytes_read"),
+					"The total of transferred bytes read from the leader. This is only an estimate and does not account for compression if enabled",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.BytesRead)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "total_write_time_millis"),
+					"The total time spent writing on the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.TotalWriteTimeMillis)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "successful_write_requests"),
+					"The number of bulk write requests executed on the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.SuccessfulWriteRequests)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "failed_write_requests"),
+					"The number of failed bulk write requests executed on the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.FailedWriteRequests)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.CounterValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "operations_written"),
+					"The number of operations written on the follower",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.OperationsWritten)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "ccr_stats", "time_since_last_read_millis"),
+					"The number of milliseconds since a read request was sent to the leader",
+					defaultCCRStatsLabels, nil,
+				),
+				Value: func(indexCCRStatsShard IndexCCRStatsShardResponse) float64 {
+					return float64(indexCCRStatsShard.TimeSinceListReadMillis)
+				},
+				Labels: defaultCCRLabelValues,
+			},
+		},
+	}
+}
+
+func (s *CCRStats) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range s.ccrMetrics {
+		ch <- metric.Desc
+	}
+	ch <- s.up.Desc()
+	ch <- s.totalScrapes.Desc()
+	ch <- s.jsonParseFailures.Desc()
+}
+
+func (s *CCRStats) fetchCCRStatsResponse() (CCRStatsResponse, error) {
+	var ccrResponse CCRStatsResponse
+
+	u := *s.url
+	u.Path = path.Join(u.Path, "/_all/_ccr/stats")
+
+	res, err := s.client.Get(u.String())
+	if err != nil {
+		return ccrResponse, fmt.Errorf("failed to get ccr statistics from %s://%s:%s%s: %s",
+			u.Scheme, u.Hostname(), u.Port(), u.Path, err)
+	}
+
+	defer func() {
+		err = res.Body.Close()
+		if err != nil {
+			_ = level.Warn(s.logger).Log(
+				"msg", "failed to close http.Client",
+				"err", err,
+			)
+		}
+	}()
+
+	if res.StatusCode != http.StatusOK {
+		return ccrResponse, fmt.Errorf("HTTP Request failed with code %d", res.StatusCode)
+	}
+
+	bts, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		s.jsonParseFailures.Inc()
+		return ccrResponse, err
+	}
+
+	if err := json.Unmarshal(bts, &ccrResponse); err != nil {
+		s.jsonParseFailures.Inc()
+		return ccrResponse, err
+	}
+	return ccrResponse, err
+}
+
+//Collect gets CCRStats metric values
+func (s *CCRStats) Collect(ch chan<- prometheus.Metric) {
+
+	s.totalScrapes.Inc()
+	defer func() {
+		ch <- s.up
+		ch <- s.totalScrapes
+		ch <- s.jsonParseFailures
+	}()
+
+	indexCCRStatsResponse, err := s.fetchCCRStatsResponse()
+	if err != nil {
+		s.up.Set(0)
+		_ = level.Warn(s.logger).Log(
+			"msg", "failed to fetch and decode CCRStats stats",
+			"err", err,
+		)
+		return
+	}
+	s.up.Set(1)
+
+	for _, indexCCRStatsResponse := range indexCCRStatsResponse.IndexCCRStats {
+		for _, indexCCRStatsShard := range indexCCRStatsResponse.IndexCCRStatsShards {
+			for _, metric := range s.ccrMetrics {
+				ch <- prometheus.MustNewConstMetric(
+					metric.Desc,
+					metric.Type,
+					metric.Value(indexCCRStatsShard),
+					metric.Labels(indexCCRStatsShard)...,
+				)
+			}
+		}
+	}
+}

--- a/collector/ccr_stats_response.go
+++ b/collector/ccr_stats_response.go
@@ -1,0 +1,52 @@
+package collector
+
+// CCRStatsResponse is a representation of the CCR stats
+type CCRStatsResponse struct {
+	IndexCCRStats []IndexCCRStatsResponse `json:"indices"`
+}
+
+// IndexCCRStatsResponse is a representation of the CCR stats per index
+type IndexCCRStatsResponse struct {
+	// The name of the follower index.
+	Index string `json:"index"`
+	// An array of shard-level following task statistics.
+	IndexCCRStatsShards []IndexCCRStatsShardResponse `json:"shards"`
+}
+
+type ReadException struct {
+	Exception []interface{} `json:"exception"`
+	FromSeqNo int64         `json:"from_seq_no"`
+	Retries   int64         `json:"retries"`
+}
+
+// IndexCCRStatsShardResponse defines CCR statistics information for shard
+type IndexCCRStatsShardResponse struct {
+	RemoteCluster                 string          `json:"remote_cluster"`
+	LeaderIndex                   string          `json:"leader_index"`
+	FollowerIndex                 string          `json:"follower_index"`
+	ShardID                       int64           `json:"shard_id"`
+	LeaderGlobalCheckpoint        int64           `json:"leader_global_checkpoint"`
+	LeaderMaxSeqNo                int64           `json:"leader_max_seq_no"`
+	FollowerGlobalCheckpoint      int64           `json:"follower_global_checkpoint"`
+	FollowerMaxSeqNo              int64           `json:"follower_max_seq_no"`
+	LastRequestedSeqNo            int64           `json:"last_requested_seq_no"`
+	OutstandingReadRequests       int64           `json:"outstanding_read_requests"`
+	OutstandingWriteRequests      int64           `json:"outstanding_write_requests"`
+	WriteBufferOperationCount     int64           `json:"write_buffer_operation_count"`
+	WriteBufferSizeInBytes        int64           `json:"write_buffer_size_in_bytes"`
+	FollowerMappingVersion        int64           `json:"follower_mapping_version"`
+	FollowerSettingsVersion       int64           `json:"follower_settings_version"`
+	FollowerAliasesVersion        int64           `json:"follower_aliases_version"`
+	TotalReadTimeMillis           int64           `json:"total_read_time_millis"`
+	TotalReadRemoteExecTimeMillis int64           `json:"total_read_remote_exec_time_millis"`
+	SuccessfulReadRequests        int64           `json:"successful_read_requests"`
+	FailedReadRequests            int64           `json:"failed_read_requests"`
+	OperationsRead                int64           `json:"operations_read"`
+	BytesRead                     int64           `json:"bytes_read"`
+	TotalWriteTimeMillis          int64           `json:"total_write_time_millis"`
+	SuccessfulWriteRequests       int64           `json:"successful_write_requests"`
+	FailedWriteRequests           int64           `json:"failed_write_requests"`
+	OperationsWritten             int64           `json:"operations_written"`
+	ReadExceptions                []ReadException `json:"read_exceptions"`
+	TimeSinceListReadMillis       int64           `json:"time_since_last_read_millis"`
+}

--- a/collector/ccr_stats_test.go
+++ b/collector/ccr_stats_test.go
@@ -1,0 +1,43 @@
+package collector
+
+import (
+	"fmt"
+	"github.com/go-kit/kit/log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestCCRStats(t *testing.T) {
+
+	ti := map[string]string{
+		"7.7.1": `{"indices":[{"index":"myIndex1","shards":[{"remote_cluster":"leader_cluster","leader_index":"myIndex1","follower_index":"myIndex1","shard_id":0,"leader_global_checkpoint":1,"leader_max_seq_no":1,"follower_global_checkpoint":1,"follower_max_seq_no":1,"last_requested_seq_no":1,"outstanding_read_requests":1,"outstanding_write_requests":0,"write_buffer_operation_count":0,"write_buffer_size_in_bytes":0,"follower_mapping_version":1,"follower_settings_version":4,"follower_aliases_version":2,"total_read_time_millis":0,"total_read_remote_exec_time_millis":0,"successful_read_requests":0,"failed_read_requests":0,"operations_read":0,"bytes_read":0,"total_write_time_millis":0,"successful_write_requests":0,"failed_write_requests":0,"operations_written":0,"read_exceptions":[],"time_since_last_read_millis":44233},{"remote_cluster":"leader_cluster","leader_index":"myIndex1","follower_index":"myIndex1","shard_id":1,"leader_global_checkpoint":2,"leader_max_seq_no":2,"follower_global_checkpoint":2,"follower_max_seq_no":2,"last_requested_seq_no":2,"outstanding_read_requests":1,"outstanding_write_requests":0,"write_buffer_operation_count":0,"write_buffer_size_in_bytes":0,"follower_mapping_version":1,"follower_settings_version":4,"follower_aliases_version":2,"total_read_time_millis":0,"total_read_remote_exec_time_millis":0,"successful_read_requests":0,"failed_read_requests":0,"operations_read":0,"bytes_read":0,"total_write_time_millis":0,"successful_write_requests":0,"failed_write_requests":0,"operations_written":0,"read_exceptions":[],"time_since_last_read_millis":44130}]},{"index":"myIndex2","shards":[{"remote_cluster":"leader_cluster","leader_index":"myIndex2","follower_index":"myIndex2","shard_id":0,"leader_global_checkpoint":4,"leader_max_seq_no":4,"follower_global_checkpoint":4,"follower_max_seq_no":4,"last_requested_seq_no":4,"outstanding_read_requests":1,"outstanding_write_requests":0,"write_buffer_operation_count":0,"write_buffer_size_in_bytes":0,"follower_mapping_version":1,"follower_settings_version":4,"follower_aliases_version":2,"total_read_time_millis":0,"total_read_remote_exec_time_millis":0,"successful_read_requests":0,"failed_read_requests":0,"operations_read":0,"bytes_read":0,"total_write_time_millis":0,"successful_write_requests":0,"failed_write_requests":0,"operations_written":0,"read_exceptions":[],"time_since_last_read_millis":43920}]}]}`,
+	}
+	for ver, out := range ti {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, out)
+		}))
+		defer ts.Close()
+
+		u, err := url.Parse(ts.URL)
+		if err != nil {
+			t.Fatalf("Failed to parse URL: %s", err)
+		}
+		i := NewCCRStats(log.NewNopLogger(), http.DefaultClient, u)
+		stats, err := i.fetchCCRStatsResponse()
+		if err != nil {
+			t.Fatalf("Failed to fetch or decode CCR stats: %s", err)
+		}
+		t.Logf("[%s] CCR stats Response: %+v", ver, stats)
+		if 2 != len(stats.IndexCCRStats) {
+			t.Errorf("Number of indices is not correct. Expected statistics for two indices")
+		}
+		if 2 != len(stats.IndexCCRStats[0].IndexCCRStatsShards) {
+			t.Errorf("Wrong number of primary shards per index [%s]", stats.IndexCCRStats[0].Index)
+		}
+		if 1 != stats.IndexCCRStats[0].IndexCCRStatsShards[0].LeaderGlobalCheckpoint {
+			t.Errorf("Number representing global chakpont is not as expected")
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -70,6 +70,9 @@ func main() {
 		esExportSnapshots = kingpin.Flag("es.snapshots",
 			"Export stats for the cluster snapshots.").
 			Default("false").Envar("ES_SNAPSHOTS").Bool()
+		esExportCCRStats = kingpin.Flag("es.ccr.stats",
+			"Export CCR stats in the cluster").
+			Default("false").Envar("ES_SNAPSHOTS").Bool()
 		esClusterInfoInterval = kingpin.Flag("es.clusterinfo.interval",
 			"Cluster info update interval for the cluster label").
 			Default("5m").Envar("ES_CLUSTERINFO_INTERVAL").Duration()
@@ -143,6 +146,10 @@ func main() {
 
 	if *esExportSnapshots {
 		prometheus.MustRegister(collector.NewSnapshots(logger, httpClient, esURL))
+	}
+
+	if *esExportCCRStats {
+		prometheus.MustRegister(collector.NewCCRStats(logger, httpClient, esURL))
 	}
 
 	if *esExportClusterSettings {


### PR DESCRIPTION
Add metrics for Elasticsearch Cross Cluster Replication. Based on https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html
